### PR TITLE
Add workflows to publish to Live and Test PyPI.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,11 +1,11 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
+name: Run tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '*' ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/python-publish-live.yml
+++ b/.github/workflows/python-publish-live.yml
@@ -1,0 +1,31 @@
+# This workflow will upload the package to Live Registry of PyPI when a release is created.
+# The package will be published here: https://pypi.org/project/codeguru-profiler-agent/
+# For more information see: https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-python#publishing-to-package-registries
+
+name: Publish to Live PyPI
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.PYPI_LIVE_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+        twine upload --verbose dist/*

--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -1,0 +1,32 @@
+# This workflow will upload the package to Test Registry of PyPI when a pre-release is created.
+# The package will be published here: https://test.pypi.org/project/codeguru-profiler-agent/
+# For more information see: https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-python#publishing-to-package-registries
+
+name: Publish to Test PyPI
+
+on:
+  release:
+    types: [prereleased]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_PASSWORD }}
+        TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+        twine upload --verbose dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 pytest-report.html
+*.egg-info
+dist/*

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,32 @@
+
+# Release
+
+## How to release to PyPI
+
+#### Create PR with the new agent version
+
+- Create a pull request that updates the agent's version number in the source code [here](https://github.com/aws/amazon-codeguru-profiler-python-agent/blob/main/codeguru_profiler_agent/agent_metadata/agent_metadata.py#L12). You can use directly the editor to edit the file and create the PR.
+
+- Get approval from the [amazon-codeguru-profiler team](https://github.com/orgs/aws/teams/amazon-codeguru-profiler).
+
+- Wait until the [``Run tests`` workflow](https://github.com/aws/amazon-codeguru-profiler-python-agent/actions) passes successfully.
+
+#### Publish package to Test PyPI
+
+- Create a [new pre-release](https://github.com/aws/amazon-codeguru-profiler-python-agent/releases/new) with the agent version and details about what is changed, in the format of a changelog as [in previous releases](https://github.com/aws/amazon-codeguru-profiler-python-agent/releases). Make sure you check the box with "pre-release".
+
+- This will trigger a release to the Test Registry of PyPI, and you can track it in the [Actions tab](https://github.com/aws/amazon-codeguru-profiler-python-agent/actions).
+
+- You can use the agent now from the PyPI **Test** registry as [codeguru-profiler-agent](https://test.pypi.org/project/codeguru-profiler-agent/).
+
+#### Publish package to Live PyPI
+
+- If you want to release to the Live registry of PyPI to be used by customers, go to the [Releases tab]([here](https://test.pypi.org/project/codeguru-profiler-agent/) and edit your pre-releases as prod release.
+
+- This will trigger publishing the package to the Live Registry of PyPI, and you can track it in the [Actions tab](https://github.com/aws/amazon-codeguru-profiler-python-agent/actions).
+
+- You can use the agent now from the PyPI **Live** registry as [codeguru-profiler-agent](https://pypi.org/project/codeguru-profiler-agent/).
+
+## How to release the Lambda Layer.
+
+Check internal instructions.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Check the GitHub repository at [aws/amazon-codeguru-profiler-python-agent](https
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details.
 
-## How to release to PyPI
+## How to release
 
-Use the `setup.py` script to create the archive.
+See [DEVELOPMENT](DEVELOPMENT.md) for more information.
 
 ## Security
 

--- a/codeguru_profiler_agent/agent_metadata/agent_metadata.py
+++ b/codeguru_profiler_agent/agent_metadata/agent_metadata.py
@@ -9,7 +9,7 @@ from codeguru_profiler_agent.agent_metadata.fleet_info import DefaultFleetInfo
 # NOTE: Please do not alter the value for the following constants without the full knowledge of the use of them.
 # These constants are used in several scripts, including setup.py.
 __agent_name__ = "CodeGuruProfiler-python"
-__agent_version__ = "1.0.1"
+__agent_version__ = "1.0.2-dev.1"
 
 
 def look_up_fleet_info(

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
     packages=find_packages(exclude="test"),
 
     description="The Python agent to be used for Amazon CodeGuru Profiler",
-    long_description="https://docs.aws.amazon.com/codeguru/latest/profiler-ug/what-is-codeguru-profiler.html",
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",
     author="Amazon Web Services",
     url="https://github.com/aws/amazon-codeguru-profiler-python-agent",
     download_url="https://github.com/aws/amazon-codeguru-profiler-python-agent",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing:*

* Created release [v1.0.2-dev.1](https://github.com/mirelap-amazon/amazon-codeguru-profiler-python-agent-1/releases/tag/v1.0.2-dev.1).
* Checked that the action to publish to Test PyPI was triggered and passed successfully, more details [here](https://github.com/mirelap-amazon/amazon-codeguru-profiler-python-agent-1/actions/runs/478180565).
* Checked the Test PyPI that it was released successfully: https://test.pypi.org/project/codeguru-profiler-agent/#history

* Un-marked the 1.0.2-dev.1 as "pre-release".
* This triggered the publishing to Live PyPI [here](https://github.com/mirelap-amazon/amazon-codeguru-profiler-python-agent-1/actions/runs/478185551).
* As expected, it fails with 403 because I did not setup the right API token as secret (yet); I'll wait for the next release. I checked the logs that it tries to publish to the right PyPI instead of the test.
> Uploading distributions to https://upload.pypi.org/legacy/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
