### PR TITLE
Fix setup.py to exclude the test folder.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def find_version(*file_paths):
 setup(
     name="codeguru_profiler_agent",
     version=find_version("codeguru_profiler_agent/agent_metadata", "agent_metadata.py"),
-    packages=find_packages(exclude="test"),
+    packages=find_packages(exclude=("test",)),
 
     description="The Python agent to be used for Amazon CodeGuru Profiler",
     long_description="https://docs.aws.amazon.com/codeguru/latest/profiler-ug/what-is-codeguru-profiler.html",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing:*
I run locally ``python setup.py sdist``and checked the archive does not contain the "test" folder. Prior to this change, it contained the direct files in the test folder (and no subfolders).
> pytestutils.py
help_utils.py
conftest.py
__init__.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
