### PR TITLE
[Bug fix] Do not sample right after flushing profile

### DIFF
--- a/codeguru_profiler_agent/model/profile.py
+++ b/codeguru_profiler_agent/model/profile.py
@@ -43,9 +43,9 @@ class Profile:
     @end.setter
     def end(self, value):
         self._validate_positive_number(value)
-        if value < self.start:
+        if value <= self.start:
             raise ValueError(
-                "Profile end value must be greater than or equal to {}, got {}".format(self.start, value))
+                "Profile end value must be greater than {}, got {}".format(self.start, value))
         self._end = value
         # this is the total cpu time spent in this application since start, not just the overhead
         self.cpu_time_seconds = time.process_time() - self._start_process_time

--- a/codeguru_profiler_agent/profiler_runner.py
+++ b/codeguru_profiler_agent/profiler_runner.py
@@ -88,6 +88,7 @@ class ProfilerRunner:
         if self.is_profiling_in_progress:
             if self.collector.flush():
                 self.is_profiling_in_progress = False
+                return True
             sample = self.sampler.sample()
             self.collector.add(sample)
         return True

--- a/test/acceptance/test_live_profiling.py
+++ b/test/acceptance/test_live_profiling.py
@@ -70,12 +70,12 @@ class TestLiveProfiling:
                 finally:
                     profiler.stop()
 
-                # We should see at least 2 sample in 4 seconds as the sequence should happen in the order of
+                # We should see at least 2 samples in 4 seconds as the sequence should happen in the order of
                 # initial delay (1 second)
                 # After 1 second, no flush -> sample
                 # After 2 seconds, it attempt to flush (possibly succeed) -> sample/ no sample
                 # After 3 seconds, it attempt to flush (must succeed if it did not flush before) -> no sample/ sample
-                # After 4 seconds, no flush -> sample
+                # After 4 seconds, no flush -> sample (if profiler has not stopped yet)
                 assert wrapped_add.call_count >= 2
                 assert wrapped_post_agent_profile.call_count >= 1
                 assert wrapped_configure_agent.call_count >= 1

--- a/test/acceptance/test_live_profiling.py
+++ b/test/acceptance/test_live_profiling.py
@@ -70,7 +70,9 @@ class TestLiveProfiling:
                 finally:
                     profiler.stop()
 
-                assert wrapped_add.call_count >= 3
+                # We should only see 2 sample in 3 seconds as the sequence should happen in the order of
+                # no flush -> sample -> no flush -> sample -> flush (without sample)
+                assert wrapped_add.call_count >= 2
                 assert wrapped_post_agent_profile.call_count >= 1
                 assert wrapped_configure_agent.call_count >= 1
                 assert AgentConfiguration.get().sampling_interval == timedelta(seconds=1)

--- a/test/acceptance/test_live_profiling.py
+++ b/test/acceptance/test_live_profiling.py
@@ -66,12 +66,16 @@ class TestLiveProfiling:
                     start_status = profiler.start()
                     assert start_status
                     assert profiler.is_running()
-                    time.sleep(3)
+                    time.sleep(4)
                 finally:
                     profiler.stop()
 
-                # We should only see 2 sample in 3 seconds as the sequence should happen in the order of
-                # no flush -> sample -> no flush -> sample -> flush (without sample)
+                # We should see at least 2 sample in 4 seconds as the sequence should happen in the order of
+                # initial delay (1 second)
+                # After 1 second, no flush -> sample
+                # After 2 seconds, it attempt to flush (possibly succeed) -> sample/ no sample
+                # After 3 seconds, it attempt to flush (must succeed if it did not flush before) -> no sample/ sample
+                # After 4 seconds, no flush -> sample
                 assert wrapped_add.call_count >= 2
                 assert wrapped_post_agent_profile.call_count >= 1
                 assert wrapped_configure_agent.call_count >= 1

--- a/test/unit/test_profiler_runner.py
+++ b/test/unit/test_profiler_runner.py
@@ -73,10 +73,10 @@ class TestProfilerRunner:
         self.profiler_runner._profiling_command()
         self.mock_collector.refresh_configuration.assert_called_once()
 
-    def test_when_it_does_not_sample_when_it_reports(self):
+    def test_when_it_reports_it_does_not_sample(self):
         self.is_time_to_report = True
 
-        assert(self.profiler_runner._profiling_command())
+        assert self.profiler_runner._profiling_command()
         self.mock_collector.flush.assert_called_once()
         self.mock_collector.add.assert_not_called()
 

--- a/test/unit/test_profiler_runner.py
+++ b/test/unit/test_profiler_runner.py
@@ -73,6 +73,13 @@ class TestProfilerRunner:
         self.profiler_runner._profiling_command()
         self.mock_collector.refresh_configuration.assert_called_once()
 
+    def test_when_it_does_not_sample_when_it_reports(self):
+        self.is_time_to_report = True
+
+        assert(self.profiler_runner._profiling_command())
+        self.mock_collector.flush.assert_called_once()
+        self.mock_collector.add.assert_not_called()
+
     def test_when_disabler_say_to_stop(self):
         self.mock_disabler.should_stop_profiling.return_value = True
         self.profiler_runner._profiling_command()


### PR DESCRIPTION
There was a bug introduced from Issue #15 where we attempt to sample
right after flushing profiles even is_profiling_in_progress has been
reset to False already

*Issue #, if available:*
https://github.com/aws/amazon-codeguru-profiler-python-agent/issues/15

*Description of changes:*

We would not attempt to sample after flushing the profile given that we have also set is_profiling_in_progress to False already.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
