### PR TITLE
Attempt to improve implementation of ProfilerDisabler

### DIFF
--- a/codeguru_profiler_agent/local_aggregator.py
+++ b/codeguru_profiler_agent/local_aggregator.py
@@ -44,7 +44,7 @@ class LocalAggregator:
         self.memory_limit_bytes = environment["memory_limit_bytes"]
         self.last_report_attempted = current_milli_time(clock=self.clock)
 
-        self._reset()
+        self.reset()
 
     def add(self, sample):
         """
@@ -69,7 +69,7 @@ class LocalAggregator:
                     "Profiler memory usage limit has been reached")
             self.flush(force=True)
 
-    def _reset(self):
+    def reset(self):
         self.profile = self.profile_factory(
             profiling_group_name=self.profiling_group_name,
             sampling_interval_seconds=AgentConfiguration.get().sampling_interval.total_seconds(),
@@ -80,7 +80,7 @@ class LocalAggregator:
         self.timer.reset()
 
     @with_timer("flush")
-    def flush(self, force=False):
+    def flush(self, force=False, reset=True):
         now = current_milli_time(clock=self.clock)
         reported = False
         if not force and not self._is_over_reporting_interval(now):
@@ -92,8 +92,8 @@ class LocalAggregator:
             self._report_profile(now)
             reported = True
 
-        if force or reported:
-            self._reset()
+        if force or (reset and reported):
+            self.reset()
         return reported
 
     def refresh_configuration(self):

--- a/codeguru_profiler_agent/profiler_disabler.py
+++ b/codeguru_profiler_agent/profiler_disabler.py
@@ -46,7 +46,7 @@ class CpuUsageCheck:
         """
         This function carries out an overall cpu limit check that covers the cpu overhead caused for the full
         sampling cycle: refresh config -> (sample -> aggregate) * n -> profile submission. We expect this function to
-        be called after configuration refresh and profile submission.
+        be called after profile submission.
         """
         profiler_metric = self.timer.metrics.get("runProfiler")
         if not profile or not profiler_metric or profiler_metric.counter < MINIMUM_MEASURES_IN_DURATION_METRICS:

--- a/codeguru_profiler_agent/profiler_disabler.py
+++ b/codeguru_profiler_agent/profiler_disabler.py
@@ -39,12 +39,12 @@ class CpuUsageCheck:
         self.timer = timer
 
     def is_cpu_usage_limit_reached(self, profile=None):
-        profiler_metric = self.timer.metrics.get("runProfiler")
-        if not profiler_metric or profiler_metric.counter < MINIMUM_MEASURES_IN_DURATION_METRICS:
+        sample_and_aggregate_metric = self.timer.metrics.get("sampleAndAggregate")
+        if not sample_and_aggregate_metric or sample_and_aggregate_metric.counter < MINIMUM_MEASURES_IN_DURATION_METRICS:
             return False
 
         sampling_interval_seconds = self._get_average_sampling_interval_seconds(profile)
-        used_time_percentage = 100 * profiler_metric.average() / sampling_interval_seconds
+        used_time_percentage = 100 * sample_and_aggregate_metric.average() / sampling_interval_seconds
 
         if used_time_percentage >= AgentConfiguration.get().cpu_limit_percentage:
             logger.debug(self.timer.metrics)

--- a/codeguru_profiler_agent/profiler_runner.py
+++ b/codeguru_profiler_agent/profiler_runner.py
@@ -89,9 +89,13 @@ class ProfilerRunner:
             if self.collector.flush():
                 self.is_profiling_in_progress = False
                 return True
-            sample = self.sampler.sample()
-            self.collector.add(sample)
+            self._sample_and_aggregate()
         return True
+
+    @with_timer("sampleAndAggregate")
+    def _sample_and_aggregate(self):
+        sample = self.sampler.sample()
+        self.collector.add(sample)
 
     def is_running(self):
         return self.scheduler.is_running()

--- a/codeguru_profiler_agent/profiler_runner.py
+++ b/codeguru_profiler_agent/profiler_runner.py
@@ -51,7 +51,7 @@ class ProfilerRunner:
 
         :return: True if the profiler was started successfully; False otherwise.
         """
-        if self.profiler_disabler.should_stop_sampling():
+        if self.profiler_disabler.should_stop_profiling():
             logger.info("Profiler will not start.")
             return False
         self.scheduler.start()

--- a/test/acceptance/test_cpu_limit.py
+++ b/test/acceptance/test_cpu_limit.py
@@ -31,6 +31,6 @@ class TestCPULimit:
             # With sampling_interval to be 0.01 seconds, having runProfiler as 0.5 seconds should breach
             # the cpu limit. We need to sample 20 times before we check the CPU limit
             for i in range(20):
-                self.timer.record('runProfiler', 0.5)
+                self.timer.record('sampleAndAggregate', 0.5)
 
             assert wait_for(lambda: not self.profiler.is_running(), timeout_seconds=5)

--- a/test/unit/test_profiler_disabler.py
+++ b/test/unit/test_profiler_disabler.py
@@ -28,10 +28,10 @@ def set_agent_config(sampling_interval_seconds=1, cpu_limit_percentage=DEFAULT_C
 
 
 def assert_config_sampling_interval_used(process_duration_check, profile):
-    assert process_duration_check.is_cpu_usage_limit_reached(profile)
+    assert process_duration_check.is_sampling_cpu_usage_limit_reached(profile)
 
     set_agent_config(sampling_interval_seconds=42, cpu_limit_percentage=80)
-    assert not process_duration_check.is_cpu_usage_limit_reached(profile)
+    assert not process_duration_check.is_sampling_cpu_usage_limit_reached(profile)
 
 
 class TestProfilerDisabler:
@@ -59,28 +59,57 @@ class TestSetupParameters(TestProfilerDisabler):
         assert AgentConfiguration.get().cpu_limit_percentage == DEFAULT_CPU_LIMIT_PERCENTAGE
 
 
-class TestWhenAnyFails(TestProfilerDisabler):
-    @before
-    def before(self):
-        super().before()
-        self.profiler = Mock()
-        self.disabler.killswitch = Mock()
-        self.disabler.cpu_usage_check = Mock()
-        self.disabler._is_memory_limit_reached = Mock(return_value=False)
-        self.disabler.killswitch.is_killswitch_on = Mock(return_value=False)
-        self.disabler.killswitch.is_process_duration_limit_reached = Mock(return_value=False)
+class TestShouldStopSampling:
+    class TestWhenAnyFails(TestProfilerDisabler):
+        @before
+        def before(self):
+            super().before()
+            self.disabler.killswitch = Mock()
+            self.disabler.cpu_usage_check = Mock()
+            self.disabler.cpu_usage_check.is_sampling_cpu_usage_limit_reached = Mock(return_value=False)
+            self.disabler._is_memory_limit_reached = Mock(return_value=False)
+            self.disabler.killswitch.is_killswitch_on = Mock(return_value=False)
+            self.disabler.killswitch.is_process_duration_limit_reached = Mock(return_value=False)
+            assert not self.disabler.should_stop_sampling()
 
-    def test_it_stops_profiling_if_killswitch_is_on(self):
-        self.disabler.killswitch.is_killswitch_on = Mock(return_value=True)
-        assert self.disabler.should_stop_sampling(self.profiler)
+        def test_it_stops_profiling_if_killswitch_is_on(self):
+            self.disabler.killswitch.is_killswitch_on = Mock(return_value=True)
+            assert self.disabler.should_stop_sampling()
 
-    def test_it_stops_profiling_if_memory_limit_is_reached(self):
-        self.disabler._is_memory_limit_reached = Mock(return_value=True)
-        assert self.disabler.should_stop_sampling(self.profiler)
+        def test_it_stops_profiling_if_memory_limit_is_reached(self):
+            self.disabler._is_memory_limit_reached = Mock(return_value=True)
+            assert self.disabler.should_stop_sampling()
 
-    def test_it_stops_profiling_if_process_duration_is_reached(self):
-        self.disabler.cpu_usage_check.is_cpu_usage_limit_reached = Mock(return_value=True)
-        assert self.disabler.should_stop_sampling(self.profiler)
+        def test_it_stops_profiling_if_process_duration_is_reached(self):
+            self.disabler.cpu_usage_check.is_sampling_cpu_usage_limit_reached = Mock(return_value=True)
+            assert self.disabler.should_stop_sampling()
+
+
+class TestShouldStopProfiling:
+    class TestWhenAnyFails(TestProfilerDisabler):
+        @before
+        def before(self):
+            super().before()
+            self.profiler = Mock()
+            self.disabler.killswitch = Mock()
+            self.disabler.cpu_usage_check = Mock()
+            self.disabler.cpu_usage_check.is_overall_cpu_usage_limit_reached = Mock(return_value=False)
+            self.disabler._is_memory_limit_reached = Mock(return_value=False)
+            self.disabler.killswitch.is_killswitch_on = Mock(return_value=False)
+            self.disabler.killswitch.is_process_duration_limit_reached = Mock(return_value=False)
+            assert not self.disabler.should_stop_profiling()
+
+        def test_it_stops_profiling_if_killswitch_is_on(self):
+            self.disabler.killswitch.is_killswitch_on = Mock(return_value=True)
+            assert self.disabler.should_stop_profiling()
+
+        def test_it_stops_profiling_if_memory_limit_is_reached(self):
+            self.disabler._is_memory_limit_reached = Mock(return_value=True)
+            assert self.disabler.should_stop_profiling()
+
+        def test_it_stops_profiling_if_process_duration_is_reached(self):
+            self.disabler.cpu_usage_check.is_overall_cpu_usage_limit_reached = Mock(return_value=True)
+            assert self.disabler.should_stop_profiling()
 
 
 class TestKillSwitch:
@@ -145,7 +174,7 @@ class TestWhenKillSwitchFileIsRemoved:
         assert not self.killswitch.is_killswitch_on()
 
 
-class TestCpuUsageCheck:
+class TestSamplingCpuUsageCheck:
     def before(self):
         self.timer = Timer()
         self.profile = Mock(spec=Profile)
@@ -155,7 +184,7 @@ class TestCpuUsageCheck:
         self.process_duration_check = CpuUsageCheck(self.timer)
 
 
-class TestGetAverageSamplingIntervalSeconds(TestCpuUsageCheck):
+class TestGetAverageSamplingIntervalSeconds(TestSamplingCpuUsageCheck):
     @before
     def before(self):
         super().before()
@@ -176,7 +205,7 @@ class TestGetAverageSamplingIntervalSeconds(TestCpuUsageCheck):
         assert CpuUsageCheck._get_average_sampling_interval_seconds(self.profile) == 23
 
 
-class TestIsCpuUsageLimitReached(TestCpuUsageCheck):
+class TestIsSamplingCpuUsageLimitReached(TestSamplingCpuUsageCheck):
     @before
     def before(self):
         super().before()
@@ -187,43 +216,70 @@ class TestIsCpuUsageLimitReached(TestCpuUsageCheck):
             yield
 
     def test_it_calls_get_average_sampling_interval_with_profile(self):
-        self.process_duration_check.is_cpu_usage_limit_reached(self.profile)
+        self.process_duration_check.is_sampling_cpu_usage_limit_reached(self.profile)
         self.get_average_sampling_interval_mock.assert_called_once_with(self.profile)
 
     def test_when_average_duration_exceeds_limit_it_returns_true(self):
         # timer: (0.5/4) * 100= 12.5%
-        assert self.process_duration_check.is_cpu_usage_limit_reached()
+        assert self.process_duration_check.is_sampling_cpu_usage_limit_reached()
 
-    def test_when_average_duragtion_is_below_limit_it_returns_false(self):
+    def test_when_average_duration_is_below_limit_it_returns_false(self):
         # timer: (0.5/4) * 100= 12.5%
         set_agent_config(cpu_limit_percentage=13)
-        assert not self.process_duration_check.is_cpu_usage_limit_reached()
+        assert not self.process_duration_check.is_sampling_cpu_usage_limit_reached()
 
     def test_when_profile_is_none_it_calls_get_average_sampling_interval_without_profile(self):
-        self.process_duration_check.is_cpu_usage_limit_reached()
+        self.process_duration_check.is_sampling_cpu_usage_limit_reached()
         self.get_average_sampling_interval_mock.assert_called_once_with(None)
 
 
-class TestWhenTimerDoesNotHaveTheKey(TestCpuUsageCheck):
+class TestIsOverallCpuUsageLimitReached():
+    @before
+    def before(self):
+        self.timer = Timer()
+        self.profile = Mock(spec=Profile)
+        for i in range(20):
+            self.timer.record('runProfiler', 0.5)
+        set_agent_config(cpu_limit_percentage=9)
+        self.process_duration_check = CpuUsageCheck(self.timer)
+        self.profile.get_active_millis_since_start = Mock(return_value=100*1000)
+
+    def test_when_average_duration_exceeds_limit_it_returns_true(self):
+        # timer: (0.5*20/100) * 100= 10%
+        assert self.process_duration_check.is_overall_cpu_usage_limit_reached(self.profile)
+
+    def test_when_average_duragtion_is_below_limit_it_returns_false(self):
+        # timer: (0.5*20/100) * 100= 10%
+        set_agent_config(cpu_limit_percentage=11)
+        assert not self.process_duration_check.is_overall_cpu_usage_limit_reached(self.profile)
+
+    def test_when_profile_is_none_it_returns_false(self):
+        assert not self.process_duration_check.is_overall_cpu_usage_limit_reached()
+
+
+class TestWhenTimerDoesNotHaveTheKey(TestSamplingCpuUsageCheck):
     @before
     def before(self):
         super().before()
 
     def test_it_returns_false(self):
         self.process_duration_check.timer = Timer()
-        assert not self.process_duration_check.is_cpu_usage_limit_reached()
+        assert not self.process_duration_check.is_sampling_cpu_usage_limit_reached()
 
 
-class TestWhenTimerDoesNotHaveEnoughMeasures(TestCpuUsageCheck):
+class TestWhenTimerDoesNotHaveEnoughMeasures(TestSamplingCpuUsageCheck):
     @before
     def before(self):
         super().before()
-
-    def test_it_returns_false(self):
         self.timer.reset()
         for i in range(4):
             self.timer.record('sampleAndAggregate', 0.5)
-        assert not self.process_duration_check.is_cpu_usage_limit_reached()
+
+    def test_sampling_cpu_usage_limit_reached_returns_false(self):
+        assert not self.process_duration_check.is_sampling_cpu_usage_limit_reached()
+
+    def test_overall_cpu_usage_limit_reached_returns_false(self):
+        assert not self.process_duration_check.is_overall_cpu_usage_limit_reached()
 
 
 class TestMemoryLimitCheck:

--- a/test/unit/test_profiler_disabler.py
+++ b/test/unit/test_profiler_disabler.py
@@ -72,15 +72,15 @@ class TestWhenAnyFails(TestProfilerDisabler):
 
     def test_it_stops_profiling_if_killswitch_is_on(self):
         self.disabler.killswitch.is_killswitch_on = Mock(return_value=True)
-        assert self.disabler.should_stop_profiling(self.profiler)
+        assert self.disabler.should_stop_sampling(self.profiler)
 
     def test_it_stops_profiling_if_memory_limit_is_reached(self):
         self.disabler._is_memory_limit_reached = Mock(return_value=True)
-        assert self.disabler.should_stop_profiling(self.profiler)
+        assert self.disabler.should_stop_sampling(self.profiler)
 
     def test_it_stops_profiling_if_process_duration_is_reached(self):
         self.disabler.cpu_usage_check.is_cpu_usage_limit_reached = Mock(return_value=True)
-        assert self.disabler.should_stop_profiling(self.profiler)
+        assert self.disabler.should_stop_sampling(self.profiler)
 
 
 class TestKillSwitch:

--- a/test/unit/test_profiler_disabler.py
+++ b/test/unit/test_profiler_disabler.py
@@ -248,7 +248,7 @@ class TestIsOverallCpuUsageLimitReached():
         # timer: (0.5*20/100) * 100= 10%
         assert self.process_duration_check.is_overall_cpu_usage_limit_reached(self.profile)
 
-    def test_when_average_duragtion_is_below_limit_it_returns_false(self):
+    def test_when_average_duration_is_below_limit_it_returns_false(self):
         # timer: (0.5*20/100) * 100= 10%
         set_agent_config(cpu_limit_percentage=11)
         assert not self.process_duration_check.is_overall_cpu_usage_limit_reached(self.profile)

--- a/test/unit/test_profiler_disabler.py
+++ b/test/unit/test_profiler_disabler.py
@@ -150,7 +150,7 @@ class TestCpuUsageCheck:
         self.timer = Timer()
         self.profile = Mock(spec=Profile)
         for i in range(20):
-            self.timer.record('runProfiler', 0.5)
+            self.timer.record('sampleAndAggregate', 0.5)
         set_agent_config(sampling_interval_seconds=1, cpu_limit_percentage=10)
         self.process_duration_check = CpuUsageCheck(self.timer)
 
@@ -222,7 +222,7 @@ class TestWhenTimerDoesNotHaveEnoughMeasures(TestCpuUsageCheck):
     def test_it_returns_false(self):
         self.timer.reset()
         for i in range(4):
-            self.timer.record('runProfiler', 0.5)
+            self.timer.record('sampleAndAggregate', 0.5)
         assert not self.process_duration_check.is_cpu_usage_limit_reached()
 
 


### PR DESCRIPTION
*Issue #, if available:*

#19 

*Description of changes:*

First iteration:

1. Introduce new concept in ProfilerDisabler. We break the should_stop_profiler function into 2 functions: should_stop_profiler and should_stop_sampling

2. should_stop_sampling is expected to be called whenever we sample. It does a check of the limit every time we sample (every second). This check ensure the cpu overhead brought by sampling and aggregating sample under the limit.

3. should_stop_profiler is expected to be called whenever we refresh config or submit profile. This check ensure the cpu overhead brought by refresh config and submit profile is under the limit. 

4. should_stop_profiler is calculated as "total cpu time spent on sampling + aggregating + refresh config + submit profile" divided by "profile.get_active_millis_since_start()". This formula is debatable as we are comparing cpu time against wall clock time. However, it seems to be the simplest solution with reasonable accuracy. 



Note: I am opening this PR is for discussion. The code is not at its final stage yet as it has not been tested properly yet. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
