### PR TITLE
Add create_profiling_group call to refresh_configuration() and report()

### DIFF
--- a/codeguru_profiler_agent/agent_metadata/aws_lambda.py
+++ b/codeguru_profiler_agent/agent_metadata/aws_lambda.py
@@ -2,6 +2,7 @@ import os
 import logging
 import uuid
 
+from mock import MagicMock
 from codeguru_profiler_agent.agent_metadata.fleet_info import FleetInfo
 from codeguru_profiler_agent.aws_lambda.lambda_context import LambdaContext
 
@@ -100,7 +101,12 @@ class AWSLambda(FleetInfo):
             as_map[LAMBDA_MEMORY_LIMIT_IN_MB_KEY] = str(self.memory_limit_mb)
         if self.execution_env:
             as_map[EXECUTION_ENVIRONMENT_KEY] = self.execution_env
-        if lambda_context.context is not None:
+
+        '''
+        Adding a specific condition to ignore MagicMock instances from being added to the metadata since
+        it causes boto to raise a ParamValidationError, similar to https://github.com/boto/botocore/issues/2063.
+        '''
+        if lambda_context.context is not None and not isinstance(lambda_context.context, MagicMock):
             as_map[AWS_REQUEST_ID_KEY] = lambda_context.context.aws_request_id
             as_map[LAMBDA_REMAINING_TIME_IN_MILLISECONDS_KEY] = \
                 str(lambda_context.context.get_remaining_time_in_millis())

--- a/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
+++ b/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
@@ -2,6 +2,7 @@
 
 import logging
 import io
+import os
 
 from botocore.exceptions import ClientError
 from codeguru_profiler_agent.utils.log_exception import log_exception
@@ -10,7 +11,7 @@ from codeguru_profiler_agent.metrics.with_timer import with_timer
 from codeguru_profiler_agent.sdk_reporter.profile_encoder import ProfileEncoder
 
 logger = logging.getLogger(__name__)
-
+HANDLER_ENV_NAME_FOR_CODEGURU = "HANDLER_ENV_NAME_FOR_CODEGURU"
 
 class SdkReporter(Reporter):
     """
@@ -32,6 +33,8 @@ class SdkReporter(Reporter):
         self.timer = environment.get("timer")
         self.metadata = environment["agent_metadata"]
         self.agent_config_merger = environment["agent_config_merger"]
+        self.is_lambda_one_click_pg_created_during_execution = False
+        self.is_create_pg_called_during_submit_profile = False
 
     def _encode_profile(self, profile):
         output_profile_stream = io.BytesIO()
@@ -67,8 +70,13 @@ class SdkReporter(Reporter):
             # whole process because the customer may fix this on their side by creating/changing the profiling group.
             # We handle service exceptions like this in boto3
             # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
-            if error.response['Error']['Code'] in ['ResourceNotFoundException', 'ValidationException']:
+            if error.response['Error']['Code'] == 'ValidationException':
                 self.agent_config_merger.disable_profiling()
+            if error.response['Error']['Code'] == 'ResourceNotFoundException':
+                if self.is_lambda_one_click_integration_active():
+                    self.create_pg_when_one_click_integration_is_active()
+                else:
+                    self.agent_config_merger.disable_profiling()
             self._log_request_failed(operation="configure_agent", exception=error)
         except Exception as e:
             self._log_request_failed(operation="configure_agent", exception=e)
@@ -90,9 +98,53 @@ class SdkReporter(Reporter):
             )
             logger.info("Reported profile successfully")
             return True
+        except ClientError as error:
+            if error.response['Error']['Code'] == 'ResourceNotFoundException':
+                if self.is_lambda_one_click_integration_active():
+                    self.is_create_pg_called_during_submit_profile = True
+                    self.create_pg_when_one_click_integration_is_active()
+            self._log_request_failed(operation="post_agent_profile", exception=error)
+            return False
         except Exception as e:
             self._log_request_failed(operation="post_agent_profile", exception=e)
             return False
+
+    @with_timer("createOneClickPG", measurement="wall-clock-time")
+    def create_pg_when_one_click_integration_is_active(self):
+        """
+        Create a PG for the Lambda function onboarded with 1-click integration
+        """
+        function_name = str(self.metadata.fleet_info.function_arn).split(':')[6]
+
+        profiling_group_name_for_1_click = "aws-lambda-{}".format(function_name)
+        profiling_group_name_to_be_created = os.getenv("AWS_CODEGURU_PROFILER_GROUP_NAME",
+                                                       profiling_group_name_for_1_click)
+        try:
+            self.codeguru_client_builder.codeguru_client.create_profiling_group(
+                profilingGroupName=profiling_group_name_to_be_created,
+                computePlatform='AWSLambda'
+            )
+            self.profiling_group_name = profiling_group_name_to_be_created
+            self.is_lambda_one_click_pg_created_during_execution = True
+            logger.info("Created Lambda Profiling Group with name {}", profiling_group_name_to_be_created)
+
+        except Exception as e:
+            self._log_request_failed(operation="create_profiling_group", exception=e)
+
+    def is_lambda_one_click_integration_active(self):
+        """
+        Check if the ComputeType is AWSLambda and if the environment
+        variables for Lambda Layer Profiling are set
+        """
+        fleet_info_as_map = self.metadata.fleet_info.serialize_to_map()
+        if 'computeType' in fleet_info_as_map:
+            if fleet_info_as_map['computeType'] == 'aws_lambda':
+                handler_name_ = os.environ.get(HANDLER_ENV_NAME_FOR_CODEGURU)
+                if not handler_name_:
+                    logger.error("Env Variables for CodeGuru Profiler Lambda Layer are not set. Cannot create PG.")
+                    return False
+                return True
+        return False
 
     @staticmethod
     def _log_request_failed(operation, exception):

--- a/test/unit/test_local_aggregator.py
+++ b/test/unit/test_local_aggregator.py
@@ -42,6 +42,8 @@ class TestLocalAggregator:
 
     def before(self):
         self.mock_reporter = MagicMock(name="reporter", spec=SdkReporter)
+        self.mock_reporter.lambda_one_click_pg_created_during_execution = False
+        self.mock_reporter.is_create_pg_called_during_submit_profile = False
         self.mock_profile = MagicMock(name="profile", spec=Profile)
         self.mock_profile_factory = MagicMock(
             name="profile_factory",


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
As part of Lambda 1-click integration, adding create_profiling_group call for the agent to create a profiling group during refresh_configuration() and report()

*Testing:* Pytest unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
