### PR TITLE
Add create_profiling_group call in refresh_configuration and report()

### DIFF
--- a/codeguru_profiler_agent/agent_metadata/aws_lambda.py
+++ b/codeguru_profiler_agent/agent_metadata/aws_lambda.py
@@ -2,7 +2,7 @@ import os
 import logging
 import uuid
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from codeguru_profiler_agent.agent_metadata.fleet_info import FleetInfo
 from codeguru_profiler_agent.aws_lambda.lambda_context import LambdaContext
 

--- a/codeguru_profiler_agent/agent_metadata/aws_lambda.py
+++ b/codeguru_profiler_agent/agent_metadata/aws_lambda.py
@@ -2,6 +2,7 @@ import os
 import logging
 import uuid
 
+from mock import MagicMock
 from codeguru_profiler_agent.agent_metadata.fleet_info import FleetInfo
 from codeguru_profiler_agent.aws_lambda.lambda_context import LambdaContext
 
@@ -100,7 +101,12 @@ class AWSLambda(FleetInfo):
             as_map[LAMBDA_MEMORY_LIMIT_IN_MB_KEY] = str(self.memory_limit_mb)
         if self.execution_env:
             as_map[EXECUTION_ENVIRONMENT_KEY] = self.execution_env
-        if lambda_context.context is not None:
+
+        '''
+        Adding a specific condition to ignore MagicMock instances from being added to the metadata since
+        it causes boto to raise a ParamValidationError, similar to https://github.com/boto/botocore/issues/2063.
+        '''
+        if lambda_context.context is not None and not isinstance(lambda_context.context, MagicMock):
             as_map[AWS_REQUEST_ID_KEY] = lambda_context.context.aws_request_id
             as_map[LAMBDA_REMAINING_TIME_IN_MILLISECONDS_KEY] = \
                 str(lambda_context.context.get_remaining_time_in_millis())

--- a/codeguru_profiler_agent/agent_metadata/aws_lambda.py
+++ b/codeguru_profiler_agent/agent_metadata/aws_lambda.py
@@ -10,6 +10,9 @@ logger = logging.getLogger(__name__)
 
 LAMBDA_MEMORY_SIZE_ENV = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE"
 LAMBDA_EXECUTION_ENV = "AWS_EXECUTION_ENV"
+HANDLER_ENV_NAME_FOR_CODEGURU_KEY = "HANDLER_ENV_NAME_FOR_CODEGURU"
+LAMBDA_TASK_ROOT = "LAMBDA_TASK_ROOT"
+LAMBDA_RUNTIME_DIR = "LAMBDA_RUNTIME_DIR"
 
 # Those are used for the configure agent call:
 # See https://docs.aws.amazon.com/codeguru/latest/profiler-api/API_ConfigureAgent.html

--- a/codeguru_profiler_agent/aws_lambda/lambda_handler.py
+++ b/codeguru_profiler_agent/aws_lambda/lambda_handler.py
@@ -1,9 +1,8 @@
 import os
 import logging
 from codeguru_profiler_agent.aws_lambda.profiler_decorator import with_lambda_profiler
-
+from codeguru_profiler_agent.agent_metadata.aws_lambda import HANDLER_ENV_NAME_FOR_CODEGURU_KEY
 HANDLER_ENV_NAME = "_HANDLER"
-HANDLER_ENV_NAME_FOR_CODEGURU = "HANDLER_ENV_NAME_FOR_CODEGURU"
 logger = logging.getLogger(__name__)
 
 
@@ -11,11 +10,11 @@ def restore_handler_env(original_handler, env=os.environ):
     env[HANDLER_ENV_NAME] = original_handler
 
 
-def load_handler(bootstrap_module, env=os.environ, original_handler_env_key=HANDLER_ENV_NAME_FOR_CODEGURU):
+def load_handler(bootstrap_module, env=os.environ, original_handler_env_key=HANDLER_ENV_NAME_FOR_CODEGURU_KEY):
     try:
         original_handler_name = env.get(original_handler_env_key)
         if not original_handler_name:
-            raise ValueError("Could not find module and function name from " + HANDLER_ENV_NAME_FOR_CODEGURU
+            raise ValueError("Could not find module and function name from " + HANDLER_ENV_NAME_FOR_CODEGURU_KEY
                              + " environment variable")
 
         # Delegate to the lambda code to load the customer's module.

--- a/codeguru_profiler_agent/aws_lambda/profiler_decorator.py
+++ b/codeguru_profiler_agent/aws_lambda/profiler_decorator.py
@@ -15,7 +15,8 @@ def _create_lambda_profiler(profiling_group_name, region_name, environment_overr
     from codeguru_profiler_agent.agent_metadata.aws_lambda import AWSLambda
     override = {'agent_metadata': AgentMetadata(AWSLambda.look_up_metadata(context))}
     override.update(environment_override)
-    profiler = build_profiler(pg_name=profiling_group_name, region_name=region_name, override=override, env=env)
+    profiler = build_profiler(pg_name=profiling_group_name, region_name=region_name, override=override, env=env,
+                              should_autocreate_profiling_group=True)
     if profiler is None:
         return _EmptyProfiler()
     return profiler

--- a/codeguru_profiler_agent/local_aggregator.py
+++ b/codeguru_profiler_agent/local_aggregator.py
@@ -101,7 +101,7 @@ class LocalAggregator:
         self.reporter.refresh_configuration()
 
     def _report_profile(self, now):
-        current_last_report_attempted_value = self.last_report_attempted
+        previous_last_report_attempted_value = self.last_report_attempted
         self.last_report_attempted = now
         self._add_overhead_metric_to_profile()
         logger.info("Attempting to report profile data: " + str(self.profile))
@@ -110,13 +110,13 @@ class LocalAggregator:
             return False
         is_reporting_successful = self.reporter.report(self.profile)
         '''
-        If we attempt to create a PG in the report() call, we do not want to update the last_report_attempted_value
+        If we attempt to create a Profiling Group in the report() call, we do not want to update the last_report_attempted_value
         since we did not actually report a profile.
 
-        This will occur only in the case of Lambda 1-click integration.
+        This will occur only in the case of profiling using CodeGuru Profiler Python agent Lambda layer.
         '''
         if SdkReporter.check_create_pg_called_during_submit_profile == True:
-            self.last_report_attempted = current_last_report_attempted_value
+            self.last_report_attempted = previous_last_report_attempted_value
             SdkReporter.reset_check_create_pg_called_during_submit_profile_flag()
         return is_reporting_successful
 

--- a/codeguru_profiler_agent/local_aggregator.py
+++ b/codeguru_profiler_agent/local_aggregator.py
@@ -6,6 +6,7 @@ from codeguru_profiler_agent.reporter.agent_configuration import AgentConfigurat
 from codeguru_profiler_agent.metrics.with_timer import with_timer
 from codeguru_profiler_agent.model.profile import Profile
 from codeguru_profiler_agent.utils.time import current_milli_time
+from codeguru_profiler_agent.sdk_reporter.sdk_reporter import SdkReporter
 
 logger = logging.getLogger(__name__)
 
@@ -100,13 +101,24 @@ class LocalAggregator:
         self.reporter.refresh_configuration()
 
     def _report_profile(self, now):
+        current_last_report_attempted_value = self.last_report_attempted
         self.last_report_attempted = now
         self._add_overhead_metric_to_profile()
         logger.info("Attempting to report profile data: " + str(self.profile))
         if self.profile.is_empty():
             logger.info("Report was cancelled because it was empty")
             return False
-        return self.reporter.report(self.profile)
+        is_reporting_successful = self.reporter.report(self.profile)
+        '''
+        If we attempt to create a PG in the report() call, we do not want to update the last_report_attempted_value
+        since we did not actually report a profile.
+
+        This will occur only in the case of Lambda 1-click integration.
+        '''
+        if SdkReporter.check_create_pg_called_during_submit_profile == True:
+            self.last_report_attempted = current_last_report_attempted_value
+            SdkReporter.reset_check_create_pg_called_during_submit_profile_flag()
+        return is_reporting_successful
 
     def _is_under_min_reporting_time(self, now):
         return AgentConfiguration.get().is_under_min_reporting_time(now - self.last_report_attempted)

--- a/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
+++ b/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
@@ -54,6 +54,11 @@ class SdkReporter(Reporter):
     def refresh_configuration(self):
         """
         Refresh the agent configuration by calling the profiler backend service.
+
+        Note:
+        For an agent running on AWS Lambda, if the environment variables for Profiling using
+        Lambda layers are set, it tries to create a Profiling Group whenever a ResourceNotFoundException
+        is encountered.
         """
         try:
             fleet_instance_id = self.metadata.fleet_info.get_fleet_instance_id()
@@ -91,6 +96,11 @@ class SdkReporter(Reporter):
 
         :param profile: Profile to be encoded and reported to the profiler backend service.
         :return: True if profile gets reported successfully; False otherwise.
+
+        Note:
+        For an agent running on AWS Lambda, if the environment variables for Profiling using
+        Lambda layers are set, it tries to create a Profiling Group whenever a ResourceNotFoundException
+        is encountered.
         """
         global is_create_pg_called_during_submit_profile
         try:

--- a/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
+++ b/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
@@ -34,7 +34,6 @@ class SdkReporter(Reporter):
         self.metadata = environment["agent_metadata"]
         self.agent_config_merger = environment["agent_config_merger"]
         self.is_lambda_one_click_pg_created_during_execution = False
-        # self.is_create_pg_called_during_submit_profile = False
 
     def _encode_profile(self, profile):
         output_profile_stream = io.BytesIO()
@@ -103,8 +102,8 @@ class SdkReporter(Reporter):
                 if self.is_lambda_one_click_integration_active():
                     global is_create_pg_called_during_submit_profile
                     is_create_pg_called_during_submit_profile = True
+                    logger.info("Received ResourceNotFoundException. Attempting to create 1-click PG in Report Profile")
                     self.create_pg_when_one_click_integration_is_active()
-            self._log_request_failed(operation="post_agent_profile", exception=error)
             return False
         except Exception as e:
             self._log_request_failed(operation="post_agent_profile", exception=e)

--- a/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
+++ b/codeguru_profiler_agent/sdk_reporter/sdk_reporter.py
@@ -2,6 +2,7 @@
 
 import logging
 import io
+import os
 
 from botocore.exceptions import ClientError
 from codeguru_profiler_agent.utils.log_exception import log_exception
@@ -10,14 +11,14 @@ from codeguru_profiler_agent.metrics.with_timer import with_timer
 from codeguru_profiler_agent.sdk_reporter.profile_encoder import ProfileEncoder
 
 logger = logging.getLogger(__name__)
-
+HANDLER_ENV_NAME_FOR_CODEGURU = "HANDLER_ENV_NAME_FOR_CODEGURU"
 
 class SdkReporter(Reporter):
     """
     Handles communication with the CodeGuru Profiler Service backend.
     Encodes profiles using the ProfilerEncoder and reports them using the CodeGuru profiler SDK.
     """
-
+    is_create_pg_called_during_submit_profile = False
     def __init__(self, environment):
         """
         :param environment: dependency container dictionary for the current profiler.
@@ -32,6 +33,8 @@ class SdkReporter(Reporter):
         self.timer = environment.get("timer")
         self.metadata = environment["agent_metadata"]
         self.agent_config_merger = environment["agent_config_merger"]
+        self.is_lambda_one_click_pg_created_during_execution = False
+        # self.is_create_pg_called_during_submit_profile = False
 
     def _encode_profile(self, profile):
         output_profile_stream = io.BytesIO()
@@ -67,8 +70,13 @@ class SdkReporter(Reporter):
             # whole process because the customer may fix this on their side by creating/changing the profiling group.
             # We handle service exceptions like this in boto3
             # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/error-handling.html
-            if error.response['Error']['Code'] in ['ResourceNotFoundException', 'ValidationException']:
+            if error.response['Error']['Code'] == 'ValidationException':
                 self.agent_config_merger.disable_profiling()
+            if error.response['Error']['Code'] == 'ResourceNotFoundException':
+                if self.is_lambda_one_click_integration_active():
+                    self.create_pg_when_one_click_integration_is_active()
+                else:
+                    self.agent_config_merger.disable_profiling()
             self._log_request_failed(operation="configure_agent", exception=error)
         except Exception as e:
             self._log_request_failed(operation="configure_agent", exception=e)
@@ -90,11 +98,64 @@ class SdkReporter(Reporter):
             )
             logger.info("Reported profile successfully")
             return True
+        except ClientError as error:
+            if error.response['Error']['Code'] == 'ResourceNotFoundException':
+                if self.is_lambda_one_click_integration_active():
+                    global is_create_pg_called_during_submit_profile
+                    is_create_pg_called_during_submit_profile = True
+                    self.create_pg_when_one_click_integration_is_active()
+            self._log_request_failed(operation="post_agent_profile", exception=error)
+            return False
         except Exception as e:
             self._log_request_failed(operation="post_agent_profile", exception=e)
             return False
+
+    @with_timer("createOneClickPG", measurement="wall-clock-time")
+    def create_pg_when_one_click_integration_is_active(self):
+        """
+        Create a PG for the Lambda function onboarded with 1-click integration
+        """
+        function_name = str(self.metadata.fleet_info.function_arn).split(':')[6]
+
+        profiling_group_name_for_1_click = "aws-lambda-{}".format(function_name)
+        profiling_group_name_to_be_created = os.getenv("AWS_CODEGURU_PROFILER_GROUP_NAME",
+                                                       profiling_group_name_for_1_click)
+        try:
+            self.codeguru_client_builder.codeguru_client.create_profiling_group(
+                profilingGroupName=profiling_group_name_to_be_created,
+                computePlatform='AWSLambda'
+            )
+            self.profiling_group_name = profiling_group_name_to_be_created
+            self.is_lambda_one_click_pg_created_during_execution = True
+            logger.info("Created Lambda Profiling Group with name {}", profiling_group_name_to_be_created)
+
+        except Exception as e:
+            self._log_request_failed(operation="create_profiling_group", exception=e)
+
+    def is_lambda_one_click_integration_active(self):
+        """
+        Check if the ComputeType is AWSLambda and if the environment
+        variables for Lambda Layer Profiling are set
+        """
+        fleet_info_as_map = self.metadata.fleet_info.serialize_to_map()
+        if 'computeType' in fleet_info_as_map:
+            if fleet_info_as_map['computeType'] == 'aws_lambda':
+                handler_name_ = os.environ.get(HANDLER_ENV_NAME_FOR_CODEGURU)
+                if not handler_name_:
+                    logger.error("Env Variables for CodeGuru Profiler Lambda Layer are not set. Cannot create PG.")
+                    return False
+                return True
+        return False
 
     @staticmethod
     def _log_request_failed(operation, exception):
         log_exception(logger, "Failed to call the CodeGuru Profiler service for the {} operation: {}"
                       .format(operation, str(exception)))
+
+    @classmethod
+    def check_create_pg_called_during_submit_profile(cls):
+        return cls.is_create_pg_called_during_submit_profile
+
+    @classmethod
+    def reset_check_create_pg_called_during_submit_profile_flag(cls):
+        cls.is_create_pg_called_during_submit_profile = False

--- a/test/acceptance/test_end_to_end_profile_and_save_to_file.py
+++ b/test/acceptance/test_end_to_end_profile_and_save_to_file.py
@@ -5,7 +5,7 @@ import tempfile
 import os
 
 from datetime import timedelta
-from mock import patch
+from unittest.mock import patch
 from pathlib import Path
 
 from codeguru_profiler_agent.profiler import Profiler

--- a/test/acceptance/test_end_to_end_profiling.py
+++ b/test/acceptance/test_end_to_end_profiling.py
@@ -33,6 +33,9 @@ class TestEndToEndProfiling:
         with \
                 patch(
                     "codeguru_profiler_agent.reporter.agent_configuration.AgentConfiguration.is_under_min_reporting_time",
+                    return_value=False), \
+                patch(
+                    "codeguru_profiler_agent.sdk_reporter.sdk_reporter.SdkReporter.check_create_pg_called_during_submit_profile",
                     return_value=False):
             with self.client_stubber:
                 self.profiler.start()

--- a/test/acceptance/test_end_to_end_profiling.py
+++ b/test/acceptance/test_end_to_end_profiling.py
@@ -1,6 +1,6 @@
 from botocore.stub import Stubber, ANY
 from datetime import timedelta
-from mock import patch
+from unittest.mock import patch
 from test.pytestutils import before
 
 from codeguru_profiler_agent.profiler import Profiler

--- a/test/acceptance/test_live_profiling.py
+++ b/test/acceptance/test_live_profiling.py
@@ -1,7 +1,7 @@
 import time
 
 from datetime import timedelta
-from mock import patch
+from unittest.mock import patch
 
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
 from codeguru_profiler_agent.sdk_reporter.sdk_reporter import SdkReporter

--- a/test/acceptance/test_live_profiling.py
+++ b/test/acceptance/test_live_profiling.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from mock import patch
 
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
+from codeguru_profiler_agent.sdk_reporter.sdk_reporter import SdkReporter
 from codeguru_profiler_agent.profiler import Profiler
 from codeguru_profiler_agent.agent_metadata.agent_metadata import AgentMetadata, DefaultFleetInfo
 from test.help_utils import DUMMY_TEST_PROFILING_GROUP_NAME
@@ -15,6 +16,9 @@ class TestLiveProfiling:
         with \
                 patch(
                     "codeguru_profiler_agent.reporter.agent_configuration.AgentConfiguration.is_under_min_reporting_time",
+                    return_value=False), \
+                patch(
+                    "codeguru_profiler_agent.sdk_reporter.sdk_reporter.SdkReporter.check_create_pg_called_during_submit_profile",
                     return_value=False), \
                 patch(
                     "codeguru_profiler_agent.reporter.agent_configuration.AgentConfiguration._is_reporting_interval_smaller_than_minimum_allowed",

--- a/test/unit/agent_metadata/test_aws_lambda.py
+++ b/test/unit/agent_metadata/test_aws_lambda.py
@@ -1,6 +1,6 @@
 import pytest
 from test.pytestutils import before
-from mock import Mock
+from unittest.mock import Mock
 from datetime import timedelta
 from codeguru_profiler_agent.agent_metadata.aws_lambda import AWSLambda
 from codeguru_profiler_agent.aws_lambda.lambda_context import LambdaContext

--- a/test/unit/aws_lambda/test_profiler_decorator.py
+++ b/test/unit/aws_lambda/test_profiler_decorator.py
@@ -1,7 +1,7 @@
 import pytest
 import codeguru_profiler_agent.aws_lambda.profiler_decorator
 
-from mock import MagicMock, patch
+from unittest.mock import MagicMock
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
 from codeguru_profiler_agent import with_lambda_profiler
 from codeguru_profiler_agent import Profiler
@@ -71,7 +71,7 @@ class TestWithParameters:
         self.context = MagicMock()
         self.context.invoked_function_arn = "the_lambda_function_arn"
         self.env = {"AWS_LAMBDA_FUNCTION_MEMORY_SIZE": "1024",
-                    "AWS_EXECUTION_ENV": "AWS_Lambda_python3.6"}
+                    "AWS_EXECUTION_ENV_KEY": "AWS_Lambda_python3.6"}
 
         # define a handler function with the profiler decorator and parameters
         @with_lambda_profiler(profiling_group_name="pg_name", region_name="eu-north-1",

--- a/test/unit/file_reporter/test_file_reporter.py
+++ b/test/unit/file_reporter/test_file_reporter.py
@@ -2,8 +2,8 @@ import tempfile
 import pytest
 import shutil
 
-from mock import MagicMock
-from mock import ANY
+from unittest.mock import MagicMock
+from unittest.mock import ANY
 from pathlib import Path
 
 from codeguru_profiler_agent.file_reporter.file_reporter import FileReporter

--- a/test/unit/model/test_call_graph_node.py
+++ b/test/unit/model/test_call_graph_node.py
@@ -2,7 +2,7 @@ import pytest
 
 from codeguru_profiler_agent.model.frame import Frame
 from test.pytestutils import before
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from codeguru_profiler_agent.model.call_graph_node import CallGraphNode
 from codeguru_profiler_agent.model.memory_counter import MemoryCounter

--- a/test/unit/model/test_profile.py
+++ b/test/unit/model/test_profile.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from codeguru_profiler_agent.model.frame import Frame
 from test.pytestutils import before

--- a/test/unit/sdk_reporter/test_sdk_profile_encoder.py
+++ b/test/unit/sdk_reporter/test_sdk_profile_encoder.py
@@ -2,7 +2,7 @@
 import platform
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from codeguru_profiler_agent.agent_metadata.agent_metadata import AgentMetadata
 from codeguru_profiler_agent.agent_metadata.aws_ec2_instance import AWSEC2Instance

--- a/test/unit/sdk_reporter/test_sdk_reporter.py
+++ b/test/unit/sdk_reporter/test_sdk_reporter.py
@@ -245,7 +245,7 @@ class TestConfigureAgent(TestSdkReporter):
         self.subject.profiling_group_name = autocreated_test_lambda_profiling_group_name
         with self.client_stubber:
             self.subject.refresh_configuration()
-            assert self.subject.is_profiling_group_created_during_execution is True
+            self.client_stubber.assert_no_pending_responses()
 
     def test_create_pg_not_invoked_in_non_lambda_case(self):
         self.client_stubber.add_client_error('configure_agent',
@@ -255,5 +255,4 @@ class TestConfigureAgent(TestSdkReporter):
 
         with self.client_stubber:
             self.subject.refresh_configuration()
-            assert self.subject.is_profiling_group_created_during_execution is False
             self.client_stubber.assert_no_pending_responses()

--- a/test/unit/test_codeguru_client_builder.py
+++ b/test/unit/test_codeguru_client_builder.py
@@ -2,7 +2,7 @@ import os
 
 import boto3
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from test.pytestutils import before
 from codeguru_profiler_agent.codeguru_client_builder import CodeGuruClientBuilder

--- a/test/unit/test_local_aggregator.py
+++ b/test/unit/test_local_aggregator.py
@@ -42,7 +42,7 @@ class TestLocalAggregator:
 
     def before(self):
         self.mock_reporter = MagicMock(name="reporter", spec=SdkReporter)
-        self.mock_reporter.lambda_one_click_pg_created_during_execution = False
+        self.mock_reporter.is_profiling_group_created_during_execution = False
         self.mock_profile = MagicMock(name="profile", spec=Profile)
         self.mock_profile_factory = MagicMock(
             name="profile_factory",

--- a/test/unit/test_local_aggregator.py
+++ b/test/unit/test_local_aggregator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
 from codeguru_profiler_agent.utils.time import current_milli_time
 from test.pytestutils import before
-from mock import MagicMock, call
+from mock import MagicMock, call, patch
 
 from codeguru_profiler_agent.profiler import DEFAULT_REPORTING_INTERVAL, \
     DEFAULT_MEMORY_LIMIT_BYTES, Profiler, INITIAL_MINIMUM_REPORTING_INTERVAL, DEFAULT_SAMPLING_INTERVAL
@@ -42,6 +42,7 @@ class TestLocalAggregator:
 
     def before(self):
         self.mock_reporter = MagicMock(name="reporter", spec=SdkReporter)
+        self.mock_reporter.lambda_one_click_pg_created_during_execution = False
         self.mock_profile = MagicMock(name="profile", spec=Profile)
         self.mock_profile_factory = MagicMock(
             name="profile_factory",

--- a/test/unit/test_local_aggregator.py
+++ b/test/unit/test_local_aggregator.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
 from codeguru_profiler_agent.utils.time import current_milli_time
 from test.pytestutils import before
-from mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call
 
 from codeguru_profiler_agent.profiler import DEFAULT_REPORTING_INTERVAL, \
     DEFAULT_MEMORY_LIMIT_BYTES, Profiler, INITIAL_MINIMUM_REPORTING_INTERVAL, DEFAULT_SAMPLING_INTERVAL

--- a/test/unit/test_local_aggregator.py
+++ b/test/unit/test_local_aggregator.py
@@ -42,7 +42,6 @@ class TestLocalAggregator:
 
     def before(self):
         self.mock_reporter = MagicMock(name="reporter", spec=SdkReporter)
-        self.mock_reporter.is_profiling_group_created_during_execution = False
         self.mock_profile = MagicMock(name="profile", spec=Profile)
         self.mock_profile_factory = MagicMock(
             name="profile_factory",

--- a/test/unit/test_profiler.py
+++ b/test/unit/test_profiler.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import timedelta
-from mock import Mock
+from unittest.mock import Mock
 from codeguru_profiler_agent.profiler import Profiler
 from codeguru_profiler_agent.profiler_runner import ProfilerRunner
 

--- a/test/unit/test_profiler_disabler.py
+++ b/test/unit/test_profiler_disabler.py
@@ -1,7 +1,7 @@
 import tempfile
 from pathlib import Path
 import shutil
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 import time
 
 from codeguru_profiler_agent.model.profile import Profile

--- a/test/unit/test_profiler_runner.py
+++ b/test/unit/test_profiler_runner.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
 from test.pytestutils import before
 from test.help_utils import wait_for
-from mock import MagicMock
+from unittest.mock import MagicMock
 from time import sleep
 
 from codeguru_profiler_agent.profiler_runner import ProfilerRunner

--- a/test/unit/test_sampler.py
+++ b/test/unit/test_sampler.py
@@ -1,6 +1,6 @@
 from codeguru_profiler_agent.reporter.agent_configuration import AgentConfiguration
 from test.pytestutils import before
-import mock
+import unittest.mock as mock
 from mock import create_autospec, MagicMock, ANY
 
 from codeguru_profiler_agent.sampler import Sampler

--- a/test/unit/test_sampling_utils.py
+++ b/test/unit/test_sampling_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import mock
+import unittest.mock as mock
 import sys
 
 from test import help_utils

--- a/test/unit/utils/test_execution_state.py
+++ b/test/unit/utils/test_execution_state.py
@@ -3,7 +3,7 @@ import time
 import datetime
 from test.pytestutils import before
 from queue import Queue, Empty
-from mock import MagicMock, call
+from unittest.mock import MagicMock, call
 
 from codeguru_profiler_agent.utils.execution_state import ExecutionState
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As part of Lambda 1-click integration, we want the agent to create a profiling group for the user if it does not exist. To do this, we add a create_profiling_group API call in places where we could receive a ResourceNotFoundException for the PG.

*Testing:* Pytest unit tests.
Tested on a sample app in my AWS account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
