### PR TITLE
Add synthetic frame for `queue.get(block=True)`

### DIFF
--- a/codeguru_profiler_agent/sampling_utils.py
+++ b/codeguru_profiler_agent/sampling_utils.py
@@ -11,6 +11,7 @@ TRUNCATED_FRAME = Frame(name="<Truncated>")
 
 TIME_SLEEP_FRAME = Frame(name="<Sleep>")
 LXML_SCHEMA_FRAME = Frame(name="lxml.etree:XMLSchema:__init__")
+QUEUE_BLOCKING_GET_FRAME = Frame(name="<queue.get>")
 
 
 def get_stacks(threads_to_sample, excluded_threads, max_depth):
@@ -78,6 +79,8 @@ def _maybe_append_synthetic_frame(result, frame, line_no):
     line = linecache.getline(frame.f_code.co_filename, line_no).strip()
     if "sleep(" in line:
         result.append(TIME_SLEEP_FRAME)
+    elif ".get(block=True" in line:
+        result.append(QUEUE_BLOCKING_GET_FRAME)
     elif "etree.XMLSchema(" in line:
         result.append(LXML_SCHEMA_FRAME)
 


### PR DESCRIPTION
Whenever some python code is waiting for an item to arrive in a queue,
the current flame grpah will only show the function where the queue.get
is called, the rest of the stack is not showing. This is unfortunate
because we would need to remap those stacks into WAITING state.

This change adds another synthetic frame for this specific frame when
the source code at the end of the sampled stack has `.get(block=True`
This looks like it could trigger a lot of false positives but it will
only happen when this is the leaf of the stack so we would need this
code to call some native code that does not appear in the stack but
where we spend a lot of time.