### PR TITLE
Adds NUM_TIMES_SAMPLED agent metadata to the submitted profile

### DIFF
--- a/codeguru_profiler_agent/agent_metadata/agent_metadata.py
+++ b/codeguru_profiler_agent/agent_metadata/agent_metadata.py
@@ -67,7 +67,7 @@ class AgentMetadata:
         return self._fleet_info
 
     def serialize_to_json(self, sample_weight, duration_ms, cpu_time_seconds,
-                          average_num_threads, overhead_ms, memory_usage_mb):
+                          average_num_threads, overhead_ms, memory_usage_mb, total_sample_count):
         """
         This needs to be compliant with agent profile schema.
         """
@@ -89,7 +89,8 @@ class AgentMetadata:
                 "cpuTimeInSeconds": cpu_time_seconds,
                 "metrics": {
                     "numThreads": average_num_threads
-                }
+                },
+                "numTimesSampled": total_sample_count
             }
             if overhead_ms != 0:
                 self.json_rep["agentOverhead"]["timeInMs"] = overhead_ms

--- a/codeguru_profiler_agent/profiler_disabler.py
+++ b/codeguru_profiler_agent/profiler_disabler.py
@@ -6,7 +6,7 @@ from codeguru_profiler_agent.reporter.agent_configuration import AgentConfigurat
 logger = logging.getLogger(__name__)
 CHECK_KILLSWITCH_FILE_INTERVAL_SECONDS = 60
 MINIMUM_MEASURES_IN_DURATION_METRICS = 20
-MINIMUM_SAMPLES_IN_PROFILE = 5
+MINIMUM_SAMPLES_IN_PROFILE = 1
 
 
 class ProfilerDisabler:

--- a/codeguru_profiler_agent/profiler_disabler.py
+++ b/codeguru_profiler_agent/profiler_disabler.py
@@ -6,7 +6,7 @@ from codeguru_profiler_agent.reporter.agent_configuration import AgentConfigurat
 logger = logging.getLogger(__name__)
 CHECK_KILLSWITCH_FILE_INTERVAL_SECONDS = 60
 MINIMUM_MEASURES_IN_DURATION_METRICS = 20
-MINIMUM_SAMPLES_IN_PROFILE = 1
+MINIMUM_SAMPLES_IN_PROFILE = 5
 
 
 class ProfilerDisabler:

--- a/codeguru_profiler_agent/sdk_reporter/profile_encoder.py
+++ b/codeguru_profiler_agent/sdk_reporter/profile_encoder.py
@@ -119,7 +119,8 @@ class ProfileEncoder:
                         cpu_time_seconds=self._profile.cpu_time_seconds,
                         average_num_threads=average_num_threads,
                         memory_usage_mb=self._convert_to_mb(self._profile.get_memory_usage_bytes()),
-                        overhead_ms=self._profile.overhead_ms
+                        overhead_ms=self._profile.overhead_ms,
+                        total_sample_count = self._profile.total_sample_count
             )
 
         def _convert_to_mb(self, bytes_to_convert):

--- a/test/unit/sdk_reporter/test_sdk_profile_encoder.py
+++ b/test/unit/sdk_reporter/test_sdk_profile_encoder.py
@@ -123,6 +123,9 @@ class TestInsideTheResult(TestSdkProfileEncoder):
     def test_it_includes_the_memory_overhead_in_the_agent_metadata(self):
         assert (self.decoded_json_result()["agentMetadata"]["agentOverhead"]["memory_usage_mb"] > 0)
 
+    def test_it_includes_the_num_times_sampled_in_the_agent_metadata(self):
+        assert (self.decoded_json_result()["agentMetadata"]["numTimesSampled"] > 0)
+
     def test_it_handles_unicode_frames_correctly(self):
         self.profile.add(
             Sample(stacks=[[Frame("unicode_bottom"), Frame(u"😉"), Frame(u"🙃")]]))


### PR DESCRIPTION
*Description of changes:*
Adds serialization logic to submit `total_sample_count` as  NUM_TIMES_SAMPLED property of the AgentMetadata.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
