### PR TITLE
Remove current path from the module path in ProfileEncoder.

### DIFF
--- a/codeguru_profiler_agent/sampling_utils.py
+++ b/codeguru_profiler_agent/sampling_utils.py
@@ -87,6 +87,12 @@ def _maybe_append_synthetic_frame(result, frame, line_no):
 
 def _extract_frames(end_frame, max_depth):
     stack = list(traceback.walk_stack(end_frame))[::-1][0:max_depth]
+    # When running the sample app with uwsgi for Python 3.8.10-3.9.2, the traceback command
+    # returns a file path that contains "/.".
+    # To not let the path go into the module name, we are removing it later in the ProfileEncoder.
+    # Examples:
+    # - file '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/./polls/views.py', line 104, code get_queryset>, 104
+    # - file '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/polls/views.py', line 104, code get_queryset>, 104
     stack_entries = _extract_stack(stack, max_depth)
 
     if len(stack_entries) == max_depth:

--- a/codeguru_profiler_agent/sampling_utils.py
+++ b/codeguru_profiler_agent/sampling_utils.py
@@ -87,12 +87,9 @@ def _maybe_append_synthetic_frame(result, frame, line_no):
 
 def _extract_frames(end_frame, max_depth):
     stack = list(traceback.walk_stack(end_frame))[::-1][0:max_depth]
-    # When running the sample app with uwsgi for Python 3.8.10-3.9.2, the traceback command
-    # returns a file path that contains "/.".
+    # When running the sample app with uwsgi for Python 3.8.10 - 3.9.2, the traceback command
+    # returns a file path that contains "/./" instead of just a "/" between the app directory and the module path.
     # To not let the path go into the module name, we are removing it later in the ProfileEncoder.
-    # Examples:
-    # - file '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/./polls/views.py', line 104, code get_queryset>, 104
-    # - file '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/polls/views.py', line 104, code get_queryset>, 104
     stack_entries = _extract_stack(stack, max_depth)
 
     if len(stack_entries) == max_depth:

--- a/codeguru_profiler_agent/sdk_reporter/profile_encoder.py
+++ b/codeguru_profiler_agent/sdk_reporter/profile_encoder.py
@@ -17,17 +17,21 @@ def _get_module_path(file_path, sys_paths):
     For example, /tmp/bin/python/site-packages/great_app/simple_expansions/simple_interface.py
     will get turned into great_app.simple_expansions.simple_interface given that the syspath contains
     /tmp/bin/python/site-packages
+
+    We are making sure we're removing the current path.
+    For example, '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/./polls/views.py'
+    will get turned into `polls.views' given that the file path contains the current path.
+    This should not happen usually, but we've found a case where the "/." is added when calling traceback.walk_stack(..)
+    in a uwsgi application. Check sampling_utils.py file for details.
     """
     module_path = file_path
 
     if platform.system() == "Windows":
         # In Windows, separator can either be / or \ from experimental result
-        file_path = file_path.replace("/", os.sep)
+        module_path = module_path.replace("/", os.sep)
 
-    for root in sys_paths:
-        if root in file_path:
-            module_path = file_path.replace(root, "")
-            break
+    # remove prefix path
+    module_path = _remove_prefix_path(module_path, sys_paths)
 
     # remove suffix
     module_path = str(Path(module_path).with_suffix(""))
@@ -41,6 +45,15 @@ def _get_module_path(file_path, sys_paths):
 
     return module_path
 
+
+def _remove_prefix_path(module_path, sys_paths):
+    current_path = str(Path().absolute())
+    if current_path in module_path:
+        return module_path.replace(current_path, "").replace("/.", "")
+    for root in sys_paths:
+        if root in module_path:
+            return module_path.replace(root, "")
+    return module_path
 
 class ProfileEncoder:
     """

--- a/codeguru_profiler_agent/sdk_reporter/profile_encoder.py
+++ b/codeguru_profiler_agent/sdk_reporter/profile_encoder.py
@@ -10,7 +10,6 @@ from pathlib import Path
 GZIP_BALANCED_COMPRESSION_LEVEL = 6
 DEFAULT_FRAME_COMPONENT_DELIMITER = ":"
 
-
 def _get_module_path(file_path, sys_paths):
     """
     We tried to remove the python library root path in order to give a reasonable expression of the module path.
@@ -23,6 +22,12 @@ def _get_module_path(file_path, sys_paths):
     will get turned into `polls.views' given that the file path contains the current path.
     This should not happen usually, but we've found a case where the "/." is added when calling traceback.walk_stack(..)
     in a uwsgi application. Check sampling_utils.py file for details.
+
+    sampling_utils.py returns different values when calling traceback.walk_stack(..) for uwsgi vs non-uwsgi
+    for Python 3.8.10-Python 3.9.2.
+    Examples of results:
+    - file '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/./polls/views.py', line 104, code get_queryset>, 104
+    - file '/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app/polls/views.py', line 104, code get_queryset>, 104
     """
     module_path = file_path
 
@@ -49,7 +54,7 @@ def _get_module_path(file_path, sys_paths):
 def _remove_prefix_path(module_path, sys_paths):
     current_path = str(Path().absolute())
     if current_path in module_path:
-        return module_path.replace(current_path, "").replace("/.", "")
+        return module_path.replace(current_path, "").replace("/./", "/")
     for root in sys_paths:
         if root in module_path:
             return module_path.replace(root, "")


### PR DESCRIPTION
Running the uwsgi sample application with Python 3.8.10-3.9.2 showed incorrect module path in the UI.
This was narrowed down to `traceback` returning different results (a path with "/.").

This change makes sure the path is not leaked out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Issue #, if available:*

*Description of changes:*

*Testing:*
With this change, this is the logged module after removing the prefix :
- with this change: `INFO /polls/views.py`
- before this change for:
--`uwsgi`: `/Users/mirelap/Documents/workspace/JSON/aws-codeguru-profiler-python-demo-application/sample-demo-django-app//polls/viewspy`
--`runserver`: `/polls/views.py`

Before this change when running [this sample app](https://github.com/aws-samples/aws-codeguru-profiler-python-demo-application/tree/main/sample-demo-django-app) with uwsgi command (not with the local runserver) starting Python 3.8.10:
![Screenshot 2021-06-21 at 11 21 29](https://user-images.githubusercontent.com/65159577/122747391-ea18b000-d282-11eb-97d8-e8522648d7e2.png).

After this change:

![Screenshot 2021-06-21 at 11 55 47](https://user-images.githubusercontent.com/65159577/122751436-a7a5a200-d287-11eb-92b5-2b4c05de7ebb.png)


