### PR TITLE
Add operation name frame in stacks with boto api calls

### DIFF
--- a/test/unit/test_sampling_utils.py
+++ b/test/unit/test_sampling_utils.py
@@ -3,10 +3,19 @@ import unittest.mock as mock
 import sys
 
 from test import help_utils
+from collections import namedtuple
 
 from codeguru_profiler_agent.sampling_utils import get_stacks
 
 DEFAULT_TRUNCATED_FRAME_NAME = "<Truncated>"
+
+test_code = namedtuple('code', ['co_filename', 'co_name'])
+test_frame = namedtuple('frame', ['f_code', 'f_locals'])
+test_tb = namedtuple('tb', ['tb_frame', 'tb_lineno'])
+
+
+def make_frame(path, method, line_nbr, f_locals={}):
+    return test_tb(test_frame(test_code(path, method), f_locals), line_nbr)
 
 
 def is_frame_in_stacks(stacks, target_frame):
@@ -88,3 +97,52 @@ class TestSamplingUtils:
 
                 assert not is_frame_in_stacks(
                     stacks, "dummy_parent_method")
+
+        def test_it_adds_operation_name_frame_for_boto(self):
+            raw_stack = [
+                make_frame('path/to/foo.py', 'foo', 3),
+                make_frame('site-packages/botocore/client.py', '_api_call', 3, {'py_operation_name': 'boto_api_call'}),
+                make_frame('path/to/bar.py', 'bar', 3)
+            ]
+            with mock.patch(
+                    "traceback.walk_stack",
+                    side_effect=
+                    lambda end_frame: raw_stack
+            ):
+                stacks = get_stacks(
+                    threads_to_sample=sys._current_frames().items(),
+                    excluded_threads=set(),
+                    max_depth=100)
+                assert len(stacks[0]) == 4
+                assert is_frame_in_stacks(stacks, "boto_api_call")
+
+        def test_adding_boto_frame_does_not_exceed_maximum_depth(self):
+            raw_stack = [
+                make_frame('site-packages/botocore/client.py', '_api_call', 34, {'py_operation_name': 'boto_api_call'}),
+                make_frame('path/to/foo.py', 'bar', 12),
+
+            ]
+            for i in range(100):
+                raw_stack.insert(0, make_frame('path/to/foo.py', 'bar' + str(i), 1))
+            with mock.patch(
+                    "traceback.walk_stack",
+                    side_effect=
+                    lambda end_frame: raw_stack
+            ):
+                stacks = get_stacks(
+                    threads_to_sample=sys._current_frames().items(),
+                    excluded_threads=set(),
+                    max_depth=100)
+                assert len(stacks[0]) == 100
+                assert is_frame_in_stacks(stacks, "boto_api_call")
+
+        def test_it_adds_operation_name_frame_for_real_boto_call(self):
+            # Run a thread that will try to do a boto3 api call for 1 second then fail with a log
+            # the function will call put_metric_data on a cloudwatch client
+            # so get_stack should capture it.
+            self.helper.new_thread_sending_boto_api_call(timeout_seconds=1)
+            stacks = get_stacks(
+                threads_to_sample=sys._current_frames().items(),
+                excluded_threads=set(),
+                max_depth=100)
+            assert is_frame_in_stacks(stacks, "put_metric_data")


### PR DESCRIPTION
When using API calls from boto we often do not see the operation names
in the stack traces even though there is a dedicate function name. This
is because of the generic way that api calls are implemented in boto.
Unfortunately this is not convenient for profiling as we do not see in
flamegraphs which calls are using resources.

This change adds a specific check when we build the stacks to detect api
calls inside boto and if possible add a new frame with the operation
function name.

i.e. instead of
```
(...)
botocore.client:CloudWatch:_make_api_call
botocore.client:CloudWatch:_api_call
user_module:send_metric
```

we should end up with
```
(...)
botocore.client:CloudWatch:_make_api_call
botocore.client:CloudWatch:_api_call
botocore.client:CloudWatch:put_metric_data
user_module:send_metric
```

This new frame should help when investigating on flamegraphs but also
with automatic analysis.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
