### PR TITLE
Fix bug in module path for Fargate and ignore the "/./" for Windows.

### DIFF
--- a/test/unit/sdk_reporter/test_sdk_profile_encoder.py
+++ b/test/unit/sdk_reporter/test_sdk_profile_encoder.py
@@ -336,12 +336,19 @@ class TestModulePathExtractorWithCurrentPath:
         self.current_path = str(Path().absolute())
         self.subject = ProfileEncoder(gzip=False, environment=environment).ModulePathExtractor(sys_path=[])
 
-    def test_it_removes_current_path(self):
-        file_path = self.current_path + '/polls/views.py'
-        assert self.subject.get_module_path(file_path) == "polls.views"
-
     def test_it_removes_current_path_and_slash_and_dot(self):
         file_path = self.current_path + '/./polls/views.py'
+        if platform.system() == "Windows":
+            import os
+            # This ignores the first D:.
+            # This test just asserts the current behaviour, though the "/./" removal is not set for Windows.
+            expected = self.current_path.replace(os.sep, ".")[3:] + ".polls.views"
+        else:
+            expected = "polls.views"
+        assert self.subject.get_module_path(file_path) ==  expected
+
+    def test_it_removes_slash_and_dot(self):
+        file_path = '/./polls/views.py'
         assert self.subject.get_module_path(file_path) == "polls.views"
 
     def test_it_does_nothing_when_file_path_has_no_current_path(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I'm reconsidering [this change](https://github.com/aws/amazon-codeguru-profiler-python-agent/pull/35) to update the module path only for this specific usecase we've found for uwsgi when the "/./" is added. If other usecases arise, we can add them later.

*Testing:*

Tested it with the task published and django app from [our sample](https://github.com/aws-samples/aws-codeguru-profiler-python-demo-application) and the Fargate app we have.

Before this change, a frame in the Fargate app looked like ` optamazonbinSampleApp:<module>`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
