### PR TITLE
Send agent overhead values as int

### DIFF
--- a/codeguru_profiler_agent/agent_metadata/agent_metadata.py
+++ b/codeguru_profiler_agent/agent_metadata/agent_metadata.py
@@ -69,7 +69,7 @@ class AgentMetadata:
     def serialize_to_json(self, sample_weight, duration_ms, cpu_time_seconds,
                           average_num_threads, overhead_ms, memory_usage_mb, total_sample_count):
         """
-        This needs to be compliant with agent profile schema.
+        This needs to be compliant with the AgentMetadata schema that is used on the service side.
         """
         if self.json_rep is None:
             self.json_rep = {
@@ -83,7 +83,7 @@ class AgentMetadata:
                     "version": self.agent_info.version
                 },
                 "agentOverhead": {
-                    "memory_usage_mb": int(memory_usage_mb)
+                    "memoryInMB": int(memory_usage_mb)
                 },
                 "runtimeVersion": self.runtime_version,
                 "cpuTimeInSeconds": cpu_time_seconds,

--- a/codeguru_profiler_agent/agent_metadata/agent_metadata.py
+++ b/codeguru_profiler_agent/agent_metadata/agent_metadata.py
@@ -83,7 +83,7 @@ class AgentMetadata:
                     "version": self.agent_info.version
                 },
                 "agentOverhead": {
-                    "memory_usage_mb": memory_usage_mb
+                    "memory_usage_mb": int(memory_usage_mb)
                 },
                 "runtimeVersion": self.runtime_version,
                 "cpuTimeInSeconds": cpu_time_seconds,
@@ -93,5 +93,5 @@ class AgentMetadata:
                 "numTimesSampled": total_sample_count
             }
             if overhead_ms != 0:
-                self.json_rep["agentOverhead"]["timeInMs"] = overhead_ms
+                self.json_rep["agentOverhead"]["timeInMs"] = int(overhead_ms)
         return self.json_rep

--- a/test/acceptance/test_end_to_end_profile_and_save_to_file.py
+++ b/test/acceptance/test_end_to_end_profile_and_save_to_file.py
@@ -92,7 +92,7 @@ class TestEndToEndProfileAndSaveToFile:
         assert agent_metadata["agentOverhead"]
         assert agent_metadata["durationInMs"]
         assert agent_metadata["sampleWeights"]["WALL_TIME"]
-        assert type(agent_metadata["agentOverhead"]["memory_usage_mb"]) is int
+        assert type(agent_metadata["agentOverhead"]["memoryInMB"]) is int
 
         if platform.system() != "Windows":
             # Due to the issue mentioned on https://bugs.python.org/issue37859, we would skip checking agentOverhead for

--- a/test/acceptance/test_end_to_end_profile_and_save_to_file.py
+++ b/test/acceptance/test_end_to_end_profile_and_save_to_file.py
@@ -92,11 +92,11 @@ class TestEndToEndProfileAndSaveToFile:
         assert agent_metadata["agentOverhead"]
         assert agent_metadata["durationInMs"]
         assert agent_metadata["sampleWeights"]["WALL_TIME"]
-        assert agent_metadata["agentOverhead"]["memory_usage_mb"]
+        assert type(agent_metadata["agentOverhead"]["memory_usage_mb"]) is int
 
         if platform.system() != "Windows":
             # Due to the issue mentioned on https://bugs.python.org/issue37859, we would skip checking agentOverhead for
             # Windows system as the agent is only run for very short period of time. We may improve the accuracy of
             # measuring the overhead by using time.perf_counter_ns for Windows in the future.
-            assert agent_metadata["agentOverhead"]["timeInMs"]
+            assert type(agent_metadata["agentOverhead"]["timeInMs"]) is int
             assert agent_metadata["cpuTimeInSeconds"] > 0

--- a/test/unit/sdk_reporter/test_sdk_profile_encoder.py
+++ b/test/unit/sdk_reporter/test_sdk_profile_encoder.py
@@ -122,7 +122,7 @@ class TestInsideTheResult(TestSdkProfileEncoder):
         assert (self.decoded_json_result()["agentMetadata"]["agentOverhead"]["timeInMs"] == 256)
 
     def test_it_includes_the_memory_overhead_in_the_agent_metadata(self):
-        assert (type(self.decoded_json_result()["agentMetadata"]["agentOverhead"]["memory_usage_mb"]) is int)
+        assert (type(self.decoded_json_result()["agentMetadata"]["agentOverhead"]["memoryInMB"]) is int)
 
     def test_it_includes_the_num_times_sampled_in_the_agent_metadata(self):
         assert (self.decoded_json_result()["agentMetadata"]["numTimesSampled"] > 0)

--- a/test/unit/sdk_reporter/test_sdk_profile_encoder.py
+++ b/test/unit/sdk_reporter/test_sdk_profile_encoder.py
@@ -31,7 +31,7 @@ def example_profile():
                        [Frame("bottom"), Frame("middle"), Frame("different_top")],
                        [Frame("bottom"), Frame("middle")]], attempted_sample_threads_count=10, seen_threads_count=15))
     profile.end = end_time
-    profile.set_overhead_ms(timedelta(milliseconds=256))
+    profile.set_overhead_ms(timedelta(microseconds=256123))
     if platform.system() == "Windows":
         # In Windows, as time.process stays constant if no cpu time was used (https://bugs.python.org/issue37859), we
         # would need to manually override the cpu_time_seconds to ensure the test runs as expected
@@ -122,7 +122,7 @@ class TestInsideTheResult(TestSdkProfileEncoder):
         assert (self.decoded_json_result()["agentMetadata"]["agentOverhead"]["timeInMs"] == 256)
 
     def test_it_includes_the_memory_overhead_in_the_agent_metadata(self):
-        assert (self.decoded_json_result()["agentMetadata"]["agentOverhead"]["memory_usage_mb"] > 0)
+        assert (type(self.decoded_json_result()["agentMetadata"]["agentOverhead"]["memory_usage_mb"]) is int)
 
     def test_it_includes_the_num_times_sampled_in_the_agent_metadata(self):
         assert (self.decoded_json_result()["agentMetadata"]["numTimesSampled"] > 0)


### PR DESCRIPTION
We are currently sending the `memory_usage_mb` and `timeInMs` fields in
the agent overhead metadata, unfortunately the schema for those is INT
which means they are currently discarded when the profile is validated
at submission time. This does not prevent profiles from being accepted
but we lose the overhead data which means we will not show it in the UI.

This change converts them to int before we serialize the report.
It would be nice for the backend to accept decimals at least for the
memory since it is in MB and we may often be under 1MB. But at the
moment it is better to align to current schema.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
