### PR TITLE
Add 3.9 as supported version in the layer

### DIFF
--- a/release_layer.py
+++ b/release_layer.py
@@ -8,7 +8,7 @@ import json
 
 # The following values are used in the documentation, so any change of them requires updates to the documentation.
 LAYER_NAME = 'AWSCodeGuruProfilerPythonAgentLambdaLayer'
-SUPPORTED_VERSIONS = ['3.6', '3.7', '3.8']
+SUPPORTED_VERSIONS = ['3.6', '3.7', '3.8', '3.9']
 EXEC_SCRIPT_FILE_NAME = 'codeguru_profiler_lambda_exec'
 
 # We should release in all the regions that lambda layer is supported, not just the ones CodeGuru Profiler Service supports.


### PR DESCRIPTION
After latest change, the layer works with python 3.9 runtime.
This change is to update the release_layer script so that the layer will officially support python 3.9 as runtime.
This will be effective only for the next version of the agent

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
