### PR TITLE
Reduce Boto3 retrial attempts to 1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,8 +16,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
-
+        python-version: ['3.7', '3.8', '3.9']
+        include:
+          - os: macos-latest
+            python-version: '3.6'
+          - os: windows-latest
+            python-version: '3.6'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/codeguru_profiler_agent/codeguru_client_builder.py
+++ b/codeguru_profiler_agent/codeguru_client_builder.py
@@ -42,8 +42,11 @@ class CodeGuruClientBuilder:
         region = self._get_region_or_default()
 
         # the default retry mode is 'legacy', not 'standard'
+        # retry at most once to avoid retry storms
+        # see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html
         standard_config = Config(
-            retries={
+            retries = {
+                'max_attempts': 1,
                 'mode': 'standard'
             }
         )

--- a/release_layer.py
+++ b/release_layer.py
@@ -8,7 +8,7 @@ import json
 
 # The following values are used in the documentation, so any change of them requires updates to the documentation.
 LAYER_NAME = 'AWSCodeGuruProfilerPythonAgentLambdaLayer'
-SUPPORTED_VERSIONS = ['3.6', '3.7', '3.8', '3.9']
+SUPPORTED_VERSIONS = ['3.7', '3.8', '3.9']
 EXEC_SCRIPT_FILE_NAME = 'codeguru_profiler_lambda_exec'
 
 # We should release in all the regions that lambda layer is supported, not just the ones CodeGuru Profiler Service supports.

--- a/test/unit/metrics/test_with_timer.py
+++ b/test/unit/metrics/test_with_timer.py
@@ -15,7 +15,9 @@ class TargetClass:
     @with_timer(metric_name="test-foo-cpu", measurement="cpu-time")
     def foo_cpu(self):
         # Run something to make sure the cpu clock does tick (https://bugs.python.org/issue37859)
-        len(str(2 ** 500_000))
+        sum_x = 0
+        for i in range(10000000):
+            sum_x += i
         return
 
 


### PR DESCRIPTION
Reducing Boto3 retrial attempts to at most 1. This is to prevent unnecessary ConfigureAgent invocations when facing 429 responses.

Unfortunately Boto3 does not allow customizing the retrial strategy for a specific operation and specific error, as the Java SDK allows. This means that the PostAgentProfile call is also affected by this retrial reduction. I believe this is acceptable. Worst case scenario some 5 minutes profiles will be delayed or dropped.

Also removing Ubuntu when building Python 3.6. Unfortunately this does not work anymore. See issue https://github.com/actions/setup-python/issues/544 and broken build https://github.com/aws/amazon-codeguru-profiler-python-agent/actions/runs/3910603314/jobs/6682991145. 

I also had to update a test as it does not work anymore with latest Python versions. The integer value was too big and runs into error: `ValueError: Exceeds the limit (4300) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit`. Using `sys.set_int_max_str_digits()` failed as well. I chose to use a CPU consuming loop to test this.

Finally, I removed Python 3.6 as one the Lambda layers we release. Python 3.6 is not supported anymore by Lambda. See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
