### PR TITLE
Resolve TypeError issue for Python 3.11 when lineno is None

### DIFF
--- a/codeguru_profiler_agent/sampling_utils.py
+++ b/codeguru_profiler_agent/sampling_utils.py
@@ -97,7 +97,7 @@ def _maybe_add_boto_operation_name(raw_frame, result):
 
 
 def _maybe_append_synthetic_frame(result, frame, line_no):
-    line = linecache.getline(frame.f_code.co_filename, line_no).strip()
+    line = linecache.getline(frame.f_code.co_filename, line_no or 0).strip()
     if "sleep(" in line:
         result.append(TIME_SLEEP_FRAME)
     elif ".get(block=True" in line:


### PR DESCRIPTION
**Issue #, if available:** 53

**Description of changes:** We need to handle the case that lineno is None. It may be related to incompatiability between how traceback module is used in Python 3.11 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
